### PR TITLE
Add Survey post api

### DIFF
--- a/src/main/java/com/lubycon/devti/domain/survey/api/SurveyController.java
+++ b/src/main/java/com/lubycon/devti/domain/survey/api/SurveyController.java
@@ -1,10 +1,17 @@
 package com.lubycon.devti.domain.survey.api;
 
 
+import com.lubycon.devti.domain.survey.dto.SurveyPostDto.SurveyPostReqDto;
+import com.lubycon.devti.domain.survey.dto.SurveyPostDto.SurveyPostResDto;
 import com.lubycon.devti.domain.survey.service.SurveyService;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,5 +23,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class SurveyController {
 
   private final SurveyService surveyService;
+
+  @PostMapping
+  @ApiOperation(value = "사전 참여 신청")
+  public ResponseEntity<SurveyPostResDto> create(
+      @RequestBody @Valid SurveyPostReqDto surveyPostReqDto) {
+    return ResponseEntity.ok(surveyService.createSurvey(surveyPostReqDto));
+  }
 
 }

--- a/src/main/java/com/lubycon/devti/domain/survey/dto/SurveyPostDto.java
+++ b/src/main/java/com/lubycon/devti/domain/survey/dto/SurveyPostDto.java
@@ -1,0 +1,48 @@
+package com.lubycon.devti.domain.survey.dto;
+
+import com.lubycon.devti.domain.user.dto.UserGetDto;
+import com.lubycon.devti.global.code.SurveyType;
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class SurveyPostDto {
+
+  @Getter
+  @NoArgsConstructor
+  public static class SurveyPostReqDto {
+
+    @NotEmpty
+    @NotBlank
+    @NotNull(message = "SurveyType을 입력하세요. (ex. DEVTI)")
+    @ApiModelProperty(value = "사전 참여 조사 타입(현재는 DEVTI만 존재)", example = "DEVTI")
+    private SurveyType surveyType;
+
+    @ApiModelProperty(value = "사전 참여 조사 comment", example = "FE, BE그것이 문제로다")
+    private String comment;
+
+    @NotEmpty
+    @NotBlank
+    @NotNull(message = "Email을 입력하세요. (ex. abc@devti.com)")
+    @ApiModelProperty(value = "이메일. 필수", example = "abc@devti.com")
+    private String email;
+  }
+
+  @Getter
+  @Builder
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class SurveyPostResDto {
+
+    private Long id;
+    private String comment;
+    private UserGetDto userGetDto;
+
+  }
+
+}

--- a/src/main/java/com/lubycon/devti/domain/survey/entity/Survey.java
+++ b/src/main/java/com/lubycon/devti/domain/survey/entity/Survey.java
@@ -35,7 +35,7 @@ public class Survey extends BaseTimeEntity {
   private String comment;
 
   @Enumerated(EnumType.STRING)
-  @Column
+  @Column(nullable = false)
   private SurveyType surveyType;
 
   @JsonBackReference

--- a/src/main/java/com/lubycon/devti/domain/survey/entity/Survey.java
+++ b/src/main/java/com/lubycon/devti/domain/survey/entity/Survey.java
@@ -1,6 +1,5 @@
 package com.lubycon.devti.domain.survey.entity;
 
-import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.lubycon.devti.domain.user.entity.User;
 import com.lubycon.devti.global.code.SurveyType;
 import com.lubycon.devti.global.entity.BaseTimeEntity;
@@ -38,7 +37,6 @@ public class Survey extends BaseTimeEntity {
   @Column(nullable = false)
   private SurveyType surveyType;
 
-  @JsonBackReference
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "user_id")
   private User user;

--- a/src/main/java/com/lubycon/devti/domain/survey/service/SurveyService.java
+++ b/src/main/java/com/lubycon/devti/domain/survey/service/SurveyService.java
@@ -5,7 +5,6 @@ import com.lubycon.devti.domain.survey.dto.SurveyPostDto.SurveyPostReqDto;
 import com.lubycon.devti.domain.survey.dto.SurveyPostDto.SurveyPostResDto;
 import com.lubycon.devti.domain.survey.entity.Survey;
 import com.lubycon.devti.domain.user.dao.UserRepository;
-import com.lubycon.devti.domain.user.dto.UserGetDto;
 import com.lubycon.devti.domain.user.entity.User;
 import com.lubycon.devti.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -24,8 +23,7 @@ public class SurveyService {
 
   @Transactional
   public SurveyPostResDto createSurvey(SurveyPostReqDto surveyPostReqDto) {
-    UserGetDto userGetDto = userService.getUserByEmail(surveyPostReqDto.getEmail());
-    if (userGetDto == null) {
+    if (userService.existsUser(surveyPostReqDto.getEmail())) {
       User user = User.builder()
           .email(surveyPostReqDto.getEmail())
           .build();
@@ -47,4 +45,5 @@ public class SurveyService {
 
     return null;
   }
+
 }

--- a/src/main/java/com/lubycon/devti/domain/survey/service/SurveyService.java
+++ b/src/main/java/com/lubycon/devti/domain/survey/service/SurveyService.java
@@ -1,12 +1,50 @@
 package com.lubycon.devti.domain.survey.service;
 
+import com.lubycon.devti.domain.survey.dao.SurveyRepository;
+import com.lubycon.devti.domain.survey.dto.SurveyPostDto.SurveyPostReqDto;
+import com.lubycon.devti.domain.survey.dto.SurveyPostDto.SurveyPostResDto;
+import com.lubycon.devti.domain.survey.entity.Survey;
+import com.lubycon.devti.domain.user.dao.UserRepository;
+import com.lubycon.devti.domain.user.dto.UserGetDto;
+import com.lubycon.devti.domain.user.entity.User;
+import com.lubycon.devti.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class SurveyService {
-  
+
+  private final SurveyRepository surveyRepository;
+  private final UserRepository userRepository;
+  private final UserService userService;
+
+  @Transactional
+  public SurveyPostResDto createSurvey(SurveyPostReqDto surveyPostReqDto) {
+    UserGetDto userGetDto = userService.getUserByEmail(surveyPostReqDto.getEmail());
+    if (userGetDto == null) {
+      User user = User.builder()
+          .email(surveyPostReqDto.getEmail())
+          .build();
+      User savedUser = userRepository.save(user);
+
+      Survey survey = Survey.builder()
+          .comment(surveyPostReqDto.getComment())
+          .surveyType(surveyPostReqDto.getSurveyType())
+          .user(user)
+          .build();
+      Survey savedSurvey = surveyRepository.save(survey);
+
+      return SurveyPostResDto.builder()
+          .id(savedSurvey.getId())
+          .comment(savedSurvey.getComment())
+          .userGetDto(savedUser.toDto())
+          .build();
+    }
+
+    return null;
+  }
 }

--- a/src/main/java/com/lubycon/devti/domain/user/api/UserController.java
+++ b/src/main/java/com/lubycon/devti/domain/user/api/UserController.java
@@ -28,7 +28,7 @@ public class UserController {
   @GetMapping(value = "/{id}")
   @ApiOperation(value = "User 정보 조회")
   public ResponseEntity<UserGetDto> get(@PathVariable Long id) {
-    return ResponseEntity.ok(userService.getUser(id));
+    return ResponseEntity.ok(userService.getUserById(id));
   }
 
   @PostMapping

--- a/src/main/java/com/lubycon/devti/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/lubycon/devti/domain/user/dao/UserRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
+  User findByEmail(String email);
 }

--- a/src/main/java/com/lubycon/devti/domain/user/dao/UserRepository.java
+++ b/src/main/java/com/lubycon/devti/domain/user/dao/UserRepository.java
@@ -1,9 +1,16 @@
 package com.lubycon.devti.domain.user.dao;
 
 import com.lubycon.devti.domain.user.entity.User;
+import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
   User findByEmail(String email);
+
+  @EntityGraph(attributePaths = "surveyList")
+  @Query("select u from User u")
+  List<User> findAllEntityGraph();
 }

--- a/src/main/java/com/lubycon/devti/domain/user/entity/User.java
+++ b/src/main/java/com/lubycon/devti/domain/user/entity/User.java
@@ -49,7 +49,7 @@ public class User extends BaseTimeEntity {
   private String phone;
 
   @JsonManagedReference
-  @OneToMany(mappedBy = "survey", cascade = CascadeType.ALL, orphanRemoval = true)
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
   private Set<Survey> surveyList = new HashSet<>();
 
   public UserGetDto toDto() {

--- a/src/main/java/com/lubycon/devti/domain/user/entity/User.java
+++ b/src/main/java/com/lubycon/devti/domain/user/entity/User.java
@@ -45,7 +45,7 @@ public class User extends BaseTimeEntity {
   private Boolean newer;
 
   @PhoneNumber
-  @Column(nullable = false, unique = true)
+  @Column(unique = true)
   private String phone;
 
   @JsonManagedReference

--- a/src/main/java/com/lubycon/devti/domain/user/entity/User.java
+++ b/src/main/java/com/lubycon/devti/domain/user/entity/User.java
@@ -1,20 +1,14 @@
 package com.lubycon.devti.domain.user.entity;
 
-import com.fasterxml.jackson.annotation.JsonManagedReference;
-import com.lubycon.devti.domain.survey.entity.Survey;
 import com.lubycon.devti.domain.user.dto.UserGetDto;
 import com.lubycon.devti.global.annotation.PhoneNumber;
 import com.lubycon.devti.global.entity.BaseTimeEntity;
 import com.lubycon.devti.global.util.ModelMapperUtils;
-import java.util.HashSet;
-import java.util.Set;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
 import javax.validation.constraints.Email;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -47,10 +41,6 @@ public class User extends BaseTimeEntity {
   @PhoneNumber
   @Column(unique = true)
   private String phone;
-
-  @JsonManagedReference
-  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-  private Set<Survey> surveyList = new HashSet<>();
 
   public UserGetDto toDto() {
     return ModelMapperUtils.getInstance().map(this, UserGetDto.class);

--- a/src/main/java/com/lubycon/devti/domain/user/service/UserService.java
+++ b/src/main/java/com/lubycon/devti/domain/user/service/UserService.java
@@ -49,4 +49,9 @@ public class UserService {
     return modelMapper.map(savedUser, UserGetDto.class);
   }
 
+  public boolean existsUser(String email) {
+    UserGetDto userGetDto = getUserByEmail(email);
+    return userGetDto == null;
+  }
+
 }

--- a/src/main/java/com/lubycon/devti/domain/user/service/UserService.java
+++ b/src/main/java/com/lubycon/devti/domain/user/service/UserService.java
@@ -20,7 +20,7 @@ public class UserService {
   private final ModelMapper modelMapper;
 
   @Transactional(readOnly = true)
-  public UserGetDto getUser(Long id) {
+  public UserGetDto getUserById(Long id) {
     User user = userRepository.findById(id)
         .orElseThrow(() -> new EntityNotFoundException(id.toString()));
 

--- a/src/main/java/com/lubycon/devti/domain/user/service/UserService.java
+++ b/src/main/java/com/lubycon/devti/domain/user/service/UserService.java
@@ -39,7 +39,6 @@ public class UserService {
     return null;
   }
 
-  @Transactional
   public UserGetDto create(UserPostReqDto userPostReqDto) {
     User user = User.builder()
         .name(userPostReqDto.getName())

--- a/src/main/java/com/lubycon/devti/domain/user/service/UserService.java
+++ b/src/main/java/com/lubycon/devti/domain/user/service/UserService.java
@@ -28,6 +28,17 @@ public class UserService {
     return userGetDto;
   }
 
+  @Transactional(readOnly = true)
+  public UserGetDto getUserByEmail(String email) {
+    User user = userRepository.findByEmail(email);
+
+    if (user != null) {
+      UserGetDto userGetDto = user.toDto();
+      return userGetDto;
+    }
+    return null;
+  }
+
   @Transactional
   public UserGetDto create(UserPostReqDto userPostReqDto) {
     User user = User.builder()


### PR DESCRIPTION
## 내용
![image](https://user-images.githubusercontent.com/20061581/115870299-0615f600-a47a-11eb-999e-c49b9799d884.png)
- #11 
- 사전 참여 신청을 위한 API구현입니다.
- 사전 참여를 진행하면 Survey, User에 사용자가 추가되며 기본적으로 User(Email), Survey(Comment)가 추가됩니다.

- 함수명 변경 getUser -> getUserId
- Email로 User찾기 기능 추가 (이미 사전 참여 신청 한 사용자 구분을 위해)
- User entity에 Phone 컬럼에 `nullable = false` 처리되어있어 phone없이 사용자 추가 불가능하여 제거

## 특별히 봐줬으면 하는 부분
- Service에서 추가로 해야할 예외처리가 있는지 봐주시면 감사하겠습니다!

## 참고 사항
- Dto에 validation에 대한 Exception처리는 추후 진행하겠습니다.