### PR TITLE
Feat: bucket test, Traffic entity설계

### DIFF
--- a/src/main/java/com/lubycon/devti/domain/bucket_test_type/entity/BucketTestType.java
+++ b/src/main/java/com/lubycon/devti/domain/bucket_test_type/entity/BucketTestType.java
@@ -1,0 +1,42 @@
+package com.lubycon.devti.domain.bucket_test_type.entity;
+
+import com.lubycon.devti.global.code.TestType;
+import com.lubycon.devti.global.entity.BaseTimeEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class BucketTestType extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "BUCKET_TEST_TYPE_ID")
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "test_type", nullable = false, insertable = false, updatable = false)
+  private TestType testType;
+
+  @Column(name = "description")
+  private String description;
+
+  @Column(name = "phrases")
+  private String phrases;
+
+  @Builder
+  public BucketTestType(TestType testType, String description, String phrases) {
+    this.testType = testType;
+    this.description = description;
+    this.phrases = phrases;
+  }
+}

--- a/src/main/java/com/lubycon/devti/domain/traffic/entity/Traffic.java
+++ b/src/main/java/com/lubycon/devti/domain/traffic/entity/Traffic.java
@@ -1,0 +1,34 @@
+package com.lubycon.devti.domain.traffic.entity;
+
+import com.lubycon.devti.global.code.TestType;
+import com.lubycon.devti.global.entity.BaseTimeEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Traffic extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "TRAFFIC_ID")
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "test_type", nullable = false)
+  private TestType testType;
+
+  @Builder
+  public Traffic(TestType testType) {
+    this.testType = testType;
+  }
+}

--- a/src/main/java/com/lubycon/devti/global/code/TestType.java
+++ b/src/main/java/com/lubycon/devti/global/code/TestType.java
@@ -1,0 +1,25 @@
+package com.lubycon.devti.global.code;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum TestType implements DevtiEnumerable {
+  TYPE_COMMON_1(0), //Common type 1
+  TYPE_COMMON_2(1), //Common type 2
+  TYPE_COMMON_3(2), //Common type 3
+  TYPE_MOM_CAFE_1(3), //Mom cafe type
+  ;
+
+  private final int value;
+
+  @Override
+  public int getValue() {
+    return value;
+  }
+
+  @Override
+  public String getKey() {
+    return name();
+  }
+
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,4 +1,9 @@
-INSERT into survey (created_at, updated_at, comment, email, survey_type) values (now(), now(), 'FE,BE? ', 'user1@devti.com', 'DEVTI');
-INSERT into survey (created_at, updated_at, comment, email, survey_type) values (now(), now(), 'FE,BE? ', 'user2@devti.com', 'DEVTI');
-INSERT into survey (created_at, updated_at, comment, email, survey_type) values (now(), now(), 'FE,BE? ', 'user3@devti.com', 'DEVTI');
-INSERT into survey (created_at, updated_at, comment, email, survey_type) values (now(), now(), 'FE,BE? ', 'user4@devti.com', 'DEVTI');
+INSERT INTO survey (created_at, updated_at, comment, email, survey_type) VALUES (now(), now(), 'FE,BE? ', 'user1@devti.com', 'DEVTI');
+INSERT INTO survey (created_at, updated_at, comment, email, survey_type) VALUES (now(), now(), 'FE,BE? ', 'user2@devti.com', 'DEVTI');
+INSERT INTO survey (created_at, updated_at, comment, email, survey_type) VALUES (now(), now(), 'FE,BE? ', 'user3@devti.com', 'DEVTI');
+INSERT INTO survey (created_at, updated_at, comment, email, survey_type) VALUES (now(), now(), 'FE,BE? ', 'user4@devti.com', 'DEVTI');
+
+INSERT INTO bucket_test_type(created_at, updated_at, description, phrases, test_type) VALUES(now(), now(), "완전 현직 개발자 type", "나에게 딱 맞는 개발자 직군을 찾아보세요", 'TYPE_COMMON_1');
+INSERT INTO bucket_test_type(created_at, updated_at, description, phrases, test_type) VALUES(now(), now(), "개발자 준비 중 취업러 type", "지금, 어떤 직군에 지원해야 하는지 고민이 된다면?", 'TYPE_COMMON_2');
+INSERT INTO bucket_test_type(created_at, updated_at, description, phrases, test_type) VALUES(now(), now(), "성향 테스트를 좋아하는 사람 type", "당신도 신입 6000연봉 가능합니다", 'TYPE_COMMON_3');
+INSERT INTO bucket_test_type(created_at, updated_at, description, phrases, test_type) VALUES(now(), now(), "아이들은 위한 엄마들의 맘카페 type", "우리 아이의 코딩 잠재력을 바로 확인하세요", 'TYPE_MOM_CAFE_1');


### PR DESCRIPTION
## 내용
![image](https://user-images.githubusercontent.com/20061581/116880045-767ffc80-ac5c-11eb-8564-20b307460742.png)
![스크린샷 2021-05-03 오후 10 04 42](https://user-images.githubusercontent.com/20061581/116880083-8697dc00-ac5c-11eb-8614-86aa1d0662a8.png)
- 랜딩페이지 상단에 Bucket(A/B) test를 위한 문구를 저장해두기 위하여 BucketTestType entity설계
- Traffic 조사를 위해 방문자 history를 남기는 traffic entity설계
- 방문자가 어떤 type의 문구를 봤는지 조사하기 위하여 type컬럼이 들어가있습니다.
- TestType은 Enum으로 빼두었습니다.

## 특별히 봐줬으면 하는 부분
- BucketTestType과 Traffic의 TestType 컬럼을 연관관계를 설정해두지 않고 비즈니스 로직으로 처리하려하는데 어떻게 생각하시는지 궁금해요!

## 참고 사항
- 급한대로 Third party를 사용하지 않고 traffic 조사를 DB로 하게 되었습니다.
