### PR TITLE
Feat/bucket test #1

### DIFF
--- a/src/main/java/com/lubycon/devti/domain/bucket_test_type/api/BucketTestTypeController.java
+++ b/src/main/java/com/lubycon/devti/domain/bucket_test_type/api/BucketTestTypeController.java
@@ -1,0 +1,33 @@
+package com.lubycon.devti.domain.bucket_test_type.api;
+
+
+import com.lubycon.devti.domain.bucket_test_type.dto.BucketTestTypeGetResDto;
+import com.lubycon.devti.domain.bucket_test_type.service.BucketTestTypeService;
+import com.lubycon.devti.global.code.EntryPoint;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/bucket-test-type")
+@RequiredArgsConstructor
+@Api(value = "BucketTestType")
+public class BucketTestTypeController {
+
+  private final BucketTestTypeService bucketTestTypeService;
+
+  @GetMapping(value = "/{entryPoint}")
+  @ApiOperation(value = "Bucket test 문구 가져오기")
+  public ResponseEntity<BucketTestTypeGetResDto> getBucketTestTypeAndCreateTraffic(
+      @PathVariable final EntryPoint entryPoint) {
+    return ResponseEntity.ok(bucketTestTypeService.getBucketTestTypeAndCreateTraffic(entryPoint));
+  }
+}
+ 

--- a/src/main/java/com/lubycon/devti/domain/bucket_test_type/dao/BucketTestTypeRepository.java
+++ b/src/main/java/com/lubycon/devti/domain/bucket_test_type/dao/BucketTestTypeRepository.java
@@ -1,0 +1,10 @@
+package com.lubycon.devti.domain.bucket_test_type.dao;
+
+import com.lubycon.devti.domain.bucket_test_type.entity.BucketTestType;
+import com.lubycon.devti.global.code.TestType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BucketTestTypeRepository extends JpaRepository<BucketTestType, Long> {
+
+  BucketTestType findByTestType(TestType testType);
+}

--- a/src/main/java/com/lubycon/devti/domain/bucket_test_type/dto/BucketTestTypeGetResDto.java
+++ b/src/main/java/com/lubycon/devti/domain/bucket_test_type/dto/BucketTestTypeGetResDto.java
@@ -1,0 +1,21 @@
+package com.lubycon.devti.domain.bucket_test_type.dto;
+
+import com.lubycon.devti.global.code.TestType;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class BucketTestTypeGetResDto {
+
+  @NotNull
+  private TestType testType;
+  @NotNull
+  private String phrases;
+
+}

--- a/src/main/java/com/lubycon/devti/domain/bucket_test_type/service/BucketTestTypeService.java
+++ b/src/main/java/com/lubycon/devti/domain/bucket_test_type/service/BucketTestTypeService.java
@@ -1,0 +1,49 @@
+package com.lubycon.devti.domain.bucket_test_type.service;
+
+import com.lubycon.devti.domain.bucket_test_type.dao.BucketTestTypeRepository;
+import com.lubycon.devti.domain.bucket_test_type.dto.BucketTestTypeGetResDto;
+import com.lubycon.devti.domain.bucket_test_type.entity.BucketTestType;
+import com.lubycon.devti.domain.traffic.entity.Traffic;
+import com.lubycon.devti.domain.traffic.service.TrafficService;
+import com.lubycon.devti.global.code.EntryPoint;
+import com.lubycon.devti.global.code.TestType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BucketTestTypeService {
+
+  private final TrafficService trafficService;
+  private final BucketTestTypeRepository bucketTestTypeRepository;
+
+
+  @Transactional
+  public BucketTestTypeGetResDto getBucketTestTypeAndCreateTraffic(EntryPoint entryPoint) {
+    TestType testType = getNextTestType(entryPoint);
+
+    Traffic newTraffic = Traffic.builder()
+        .testType(testType)
+        .build();
+
+    trafficService.saveTraffic(newTraffic);
+    BucketTestType bucketTestType = bucketTestTypeRepository.findByTestType(testType);
+
+    return BucketTestTypeGetResDto.builder()
+        .testType(bucketTestType.getTestType())
+        .phrases(bucketTestType.getPhrases())
+        .build();
+  }
+
+  public TestType getNextTestType(EntryPoint entryPoint) {
+    if (entryPoint.getValue().equals("mom")) {
+      return TestType.TYPE_MOM_CAFE_1;
+    }
+    TestType lastTrafficType = trafficService.getLastTraffic().getTestType();
+
+    return lastTrafficType.getNext();
+  }
+}

--- a/src/main/java/com/lubycon/devti/domain/traffic/api/TrafficController.java
+++ b/src/main/java/com/lubycon/devti/domain/traffic/api/TrafficController.java
@@ -1,0 +1,17 @@
+package com.lubycon.devti.domain.traffic.api;
+
+
+import io.swagger.annotations.Api;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/traffic")
+@RequiredArgsConstructor
+@Api(value = "Traffic")
+public class TrafficController {
+  
+}

--- a/src/main/java/com/lubycon/devti/domain/traffic/dao/TrafficRepository.java
+++ b/src/main/java/com/lubycon/devti/domain/traffic/dao/TrafficRepository.java
@@ -1,0 +1,9 @@
+package com.lubycon.devti.domain.traffic.dao;
+
+import com.lubycon.devti.domain.traffic.entity.Traffic;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrafficRepository extends JpaRepository<Traffic, Long> {
+
+  Traffic findTopByOrderByIdDesc();
+}

--- a/src/main/java/com/lubycon/devti/domain/traffic/service/TrafficService.java
+++ b/src/main/java/com/lubycon/devti/domain/traffic/service/TrafficService.java
@@ -1,0 +1,30 @@
+package com.lubycon.devti.domain.traffic.service;
+
+import com.lubycon.devti.domain.traffic.dao.TrafficRepository;
+import com.lubycon.devti.domain.traffic.entity.Traffic;
+import com.lubycon.devti.global.code.TestType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TrafficService {
+
+  private final TrafficRepository trafficRepository;
+
+  public Traffic getLastTraffic() {
+    Traffic lastTraffic = trafficRepository.findTopByOrderByIdDesc();
+    if (lastTraffic == null) {
+      return Traffic.builder()
+          .testType(TestType.TYPE_MOM_CAFE_1)
+          .build();
+    }
+    return lastTraffic;
+  }
+
+  public Traffic saveTraffic(Traffic traffic) {
+    return trafficRepository.save(traffic);
+  }
+}

--- a/src/main/java/com/lubycon/devti/global/code/EntryPoint.java
+++ b/src/main/java/com/lubycon/devti/global/code/EntryPoint.java
@@ -1,0 +1,21 @@
+package com.lubycon.devti.global.code;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum EntryPoint {
+  COMMON_ENTRY_POINT("common"), //Common type 1
+  MOM_ENTRY_POINT("mom"), //Common type 2
+  ;
+
+  private final String value;
+
+  public String getValue() {
+    return value;
+  }
+
+  public String getKey() {
+    return name();
+  }
+
+}

--- a/src/main/java/com/lubycon/devti/global/code/TestType.java
+++ b/src/main/java/com/lubycon/devti/global/code/TestType.java
@@ -11,6 +11,7 @@ public enum TestType implements DevtiEnumerable {
   ;
 
   private final int value;
+  private static TestType[] testTypes = values();
 
   @Override
   public int getValue() {
@@ -20,6 +21,13 @@ public enum TestType implements DevtiEnumerable {
   @Override
   public String getKey() {
     return name();
+  }
+
+  public TestType getNext() {
+    if ((this.ordinal() + 1) % testTypes.length == testTypes.length - 1) {
+      return testTypes[0];
+    }
+    return testTypes[(this.ordinal() + 1) % testTypes.length];
   }
 
 }


### PR DESCRIPTION
## 내용
- 진입점 구분을 위한 Enum추가 (`common`, `mom`)
- `Mom` type을 제외한 다음 type가져오는 function추가
- `Common` type으로 진입시 `TYPE_COMMON_1`, `TYPE_COMMON_2`, `TYPE_COMMON_3`  순으로  변경되며 사용자에게 보여짐
-  `Mom` type으로 진입시 `TYPE_MOM_CAFE_1`으로 보여짐

## 참고 사항
- Stage, Master branch를 동기화 하지 않고 Master에 계속 작업을해서.. Merge커밋이 같이있습니다. 
