### PR TITLE
Feat: Survey `test_type`추가 및 Business logic 변경

### DIFF
--- a/src/main/java/com/lubycon/devti/domain/survey/api/SurveyController.java
+++ b/src/main/java/com/lubycon/devti/domain/survey/api/SurveyController.java
@@ -8,14 +8,12 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Slf4j
 @RestController
 @RequestMapping("/survey")
 @RequiredArgsConstructor

--- a/src/main/java/com/lubycon/devti/domain/survey/dao/SurveyRepository.java
+++ b/src/main/java/com/lubycon/devti/domain/survey/dao/SurveyRepository.java
@@ -1,8 +1,12 @@
 package com.lubycon.devti.domain.survey.dao;
 
 import com.lubycon.devti.domain.survey.entity.Survey;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SurveyRepository extends JpaRepository<Survey, Long> {
 
+  Optional<Survey> findByPhone(String phone);
+
+  Optional<Survey> findByEmail(String email);
 }

--- a/src/main/java/com/lubycon/devti/domain/survey/dto/SurveyPostDto.java
+++ b/src/main/java/com/lubycon/devti/domain/survey/dto/SurveyPostDto.java
@@ -1,9 +1,11 @@
 package com.lubycon.devti.domain.survey.dto;
 
 import com.lubycon.devti.global.code.SurveyType;
+import com.lubycon.devti.global.code.TestType;
 import io.swagger.annotations.ApiModelProperty;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.validation.constraints.NotBlank;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,18 +28,31 @@ public class SurveyPostDto {
 
     @ApiModelProperty(value = "휴대폰 번호", example = "010-9594-8215")
     private String phone;
+
+    @Enumerated(EnumType.STRING)
+    @ApiModelProperty(value = "Bucket test type", example = "TYPE_COMMON_1")
+    private TestType testType;
   }
 
   @Getter
-  @Builder
-  @AllArgsConstructor
-  @NoArgsConstructor
   public static class SurveyPostResDto {
 
     private Long id;
     private String comment;
     private String email;
     private String phone;
+    private TestType testType;
+
+    @Builder
+    public SurveyPostResDto(Long id, String comment, String email, String phone,
+        TestType testType) {
+      this.id = id;
+      this.comment = comment;
+      this.email = email;
+      this.phone = phone;
+      this.testType = testType;
+    }
+
   }
 
 }

--- a/src/main/java/com/lubycon/devti/domain/survey/dto/SurveyPostDto.java
+++ b/src/main/java/com/lubycon/devti/domain/survey/dto/SurveyPostDto.java
@@ -3,9 +3,9 @@ package com.lubycon.devti.domain.survey.dto;
 import com.lubycon.devti.global.code.SurveyType;
 import com.lubycon.devti.global.code.TestType;
 import io.swagger.annotations.ApiModelProperty;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,16 +20,19 @@ public class SurveyPostDto {
     @ApiModelProperty(value = "사전 참여 조사 타입(현재는 DEVTI만 존재)", example = "DEVTI")
     private SurveyType surveyType;
 
+    @Nullable
     @ApiModelProperty(value = "사전 참여 조사 comment", example = "FE, BE그것이 문제로다")
     private String comment;
 
+    @Nullable
     @ApiModelProperty(value = "이메일", example = "abc@devti.com")
     private String email;
 
+    @Nullable
     @ApiModelProperty(value = "휴대폰 번호", example = "010-9594-8215")
     private String phone;
 
-    @Enumerated(EnumType.STRING)
+    @NotNull
     @ApiModelProperty(value = "Bucket test type", example = "TYPE_COMMON_1")
     private TestType testType;
   }
@@ -52,7 +55,6 @@ public class SurveyPostDto {
       this.phone = phone;
       this.testType = testType;
     }
-
   }
 
 }

--- a/src/main/java/com/lubycon/devti/domain/survey/entity/Survey.java
+++ b/src/main/java/com/lubycon/devti/domain/survey/entity/Survey.java
@@ -1,6 +1,7 @@
 package com.lubycon.devti.domain.survey.entity;
 
 import com.lubycon.devti.global.code.SurveyType;
+import com.lubycon.devti.global.code.TestType;
 import com.lubycon.devti.global.entity.BaseTimeEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -9,7 +10,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.validation.constraints.Email;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,12 +20,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Survey extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "SURVEY_ID")
+  @Column(name = "survey_id")
   private Long id;
 
   @Column(length = 500)
@@ -34,10 +35,13 @@ public class Survey extends BaseTimeEntity {
   @Column(nullable = false)
   private SurveyType surveyType;
 
-  @Email
   @Column(length = 100, unique = true)
   private String email;
 
   @Column(length = 50, unique = true)
   private String phone;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "test_type", nullable = false)
+  private TestType testType;
 }

--- a/src/main/java/com/lubycon/devti/domain/survey/service/SurveyService.java
+++ b/src/main/java/com/lubycon/devti/domain/survey/service/SurveyService.java
@@ -4,6 +4,9 @@ import com.lubycon.devti.domain.survey.dao.SurveyRepository;
 import com.lubycon.devti.domain.survey.dto.SurveyPostDto.SurveyPostReqDto;
 import com.lubycon.devti.domain.survey.dto.SurveyPostDto.SurveyPostResDto;
 import com.lubycon.devti.domain.survey.entity.Survey;
+import com.lubycon.devti.global.error.ErrorCode;
+import com.lubycon.devti.global.error.exception.InvalidValueException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,19 +21,37 @@ public class SurveyService {
 
   @Transactional
   public SurveyPostResDto createSurvey(SurveyPostReqDto surveyPostReqDto) {
+    Optional<Survey> checkSurvey = null;
+
+    if (null != surveyPostReqDto.getPhone()) {
+      checkSurvey = surveyRepository.findByPhone(surveyPostReqDto.getPhone());
+      if (checkSurvey.isPresent()) {
+        throw new InvalidValueException(surveyPostReqDto.getEmail(), ErrorCode.PHONE_DUPLICATION);
+      }
+    } else {
+      checkSurvey = surveyRepository.findByEmail(surveyPostReqDto.getEmail());
+      if (checkSurvey.isPresent()) {
+        throw new InvalidValueException(surveyPostReqDto.getEmail(), ErrorCode.EMAIL_DUPLICATION);
+      }
+    }
 
     Survey survey = Survey.builder()
         .comment(surveyPostReqDto.getComment())
         .surveyType(surveyPostReqDto.getSurveyType())
         .email(surveyPostReqDto.getEmail())
+        .phone(surveyPostReqDto.getPhone())
+        .testType(surveyPostReqDto.getTestType())
         .build();
+
     Survey savedSurvey = surveyRepository.save(survey);
 
     return SurveyPostResDto.builder()
         .id(savedSurvey.getId())
         .comment(savedSurvey.getComment())
         .email(savedSurvey.getEmail())
+        .phone(savedSurvey.getPhone())
+        .testType(savedSurvey.getTestType())
         .build();
-  }
 
+  }
 }

--- a/src/main/java/com/lubycon/devti/domain/survey/service/SurveyService.java
+++ b/src/main/java/com/lubycon/devti/domain/survey/service/SurveyService.java
@@ -6,7 +6,6 @@ import com.lubycon.devti.domain.survey.dto.SurveyPostDto.SurveyPostResDto;
 import com.lubycon.devti.domain.survey.entity.Survey;
 import com.lubycon.devti.global.error.ErrorCode;
 import com.lubycon.devti.global.error.exception.InvalidValueException;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -21,18 +20,11 @@ public class SurveyService {
 
   @Transactional
   public SurveyPostResDto createSurvey(SurveyPostReqDto surveyPostReqDto) {
-    Optional<Survey> checkSurvey = null;
 
-    if (null != surveyPostReqDto.getPhone()) {
-      checkSurvey = surveyRepository.findByPhone(surveyPostReqDto.getPhone());
-      if (checkSurvey.isPresent()) {
-        throw new InvalidValueException(surveyPostReqDto.getEmail(), ErrorCode.PHONE_DUPLICATION);
-      }
+    if (isFilledWithPhoneSurvey(surveyPostReqDto)) {
+      checkDuplicatedSurveyByPhone(surveyPostReqDto.getPhone());
     } else {
-      checkSurvey = surveyRepository.findByEmail(surveyPostReqDto.getEmail());
-      if (checkSurvey.isPresent()) {
-        throw new InvalidValueException(surveyPostReqDto.getEmail(), ErrorCode.EMAIL_DUPLICATION);
-      }
+      checkDuplicatedSurveyByEmail(surveyPostReqDto.getEmail());
     }
 
     Survey survey = Survey.builder()
@@ -52,6 +44,21 @@ public class SurveyService {
         .phone(savedSurvey.getPhone())
         .testType(savedSurvey.getTestType())
         .build();
+  }
 
+  public boolean isFilledWithPhoneSurvey(SurveyPostReqDto surveyPostReqDto) {
+    return surveyPostReqDto.getPhone() != null;
+  }
+
+  public void checkDuplicatedSurveyByPhone(String phone) {
+    if (surveyRepository.findByPhone(phone).isPresent()) {
+      throw new InvalidValueException(phone, ErrorCode.PHONE_DUPLICATION);
+    }
+  }
+
+  public void checkDuplicatedSurveyByEmail(String email) {
+    if (surveyRepository.findByEmail(email).isPresent()) {
+      throw new InvalidValueException(email, ErrorCode.EMAIL_DUPLICATION);
+    }
   }
 }

--- a/src/main/java/com/lubycon/devti/global/error/ErrorCode.java
+++ b/src/main/java/com/lubycon/devti/global/error/ErrorCode.java
@@ -22,7 +22,7 @@ public enum ErrorCode {
 
   // Survey
   EMAIL_DUPLICATION(400, "S001", "Email is Duplication"),
-  PHONE_DUPLICATION(400, "S002", "Phone input is invalid"),
+  PHONE_DUPLICATION(400, "S002", "Phone is Duplication"),
   ;
 
   private final String code;

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,7 +1,7 @@
-INSERT INTO survey (created_at, updated_at, comment, email, survey_type) VALUES (now(), now(), 'FE,BE? ', 'user1@devti.com', 'DEVTI');
-INSERT INTO survey (created_at, updated_at, comment, email, survey_type) VALUES (now(), now(), 'FE,BE? ', 'user2@devti.com', 'DEVTI');
-INSERT into survey (created_at, updated_at, comment, phone, survey_type) values (now(), now(), 'FE,BE? ', '010-1111-2222', 'DEVTI');
-INSERT into survey (created_at, updated_at, comment, phone, survey_type) values (now(), now(), 'FE,BE? ', '010-3333-4444', 'DEVTI');
+INSERT INTO survey (created_at, updated_at, comment, email, survey_type, test_type) VALUES (now(), now(), 'FE,BE? ', 'user1@devti.com', 'DEVTI', 'TYPE_COMMON_1');
+INSERT INTO survey (created_at, updated_at, comment, email, survey_type, test_type) VALUES (now(), now(), 'FE,BE? ', 'user2@devti.com', 'DEVTI', 'TYPE_COMMON_2');
+INSERT INTO survey (created_at, updated_at, comment, phone, survey_type, test_type) VALUES (now(), now(), 'FE,BE? ', '010-1111-2222', 'DEVTI', 'TYPE_COMMON_3');
+INSERT INTO survey (created_at, updated_at, comment, phone, survey_type, test_type) VALUES (now(), now(), 'FE,BE? ', '010-3333-4444', 'DEVTI','TYPE_MOM_CAFE_1');
 
 INSERT INTO bucket_test_type(created_at, updated_at, description, phrases, test_type) VALUES(now(), now(), "완전 현직 개발자 type", "나에게 딱 맞는 개발자 직군을 찾아보세요", 'TYPE_COMMON_1');
 INSERT INTO bucket_test_type(created_at, updated_at, description, phrases, test_type) VALUES(now(), now(), "개발자 준비 중 취업러 type", "지금, 어떤 직군에 지원해야 하는지 고민이 된다면?", 'TYPE_COMMON_2');


### PR DESCRIPTION
## 내용
- 사전참여 신청을 한 유저가 어떤 type의 문구를 봤는지 확인하기 위하여 survey에 test type추가
- email, phone으로 중복 신청 안되도록 로직 추가

## 특별히 봐줬으면 하는 부분
- Business logic을 더 깔끔하게 짤수있을까요?